### PR TITLE
[beta 待ち] [Navigation] 2.2.0

### DIFF
--- a/NavigationSample/README.md
+++ b/NavigationSample/README.md
@@ -4,12 +4,9 @@
 
 ## 対象バージョン
 
-2.1.0-beta02
+2.2.0-beta01
 
 ## TODO
-
-* navgraphViewModels
-* dialog destination
 
 ## サンプル
 
@@ -27,6 +24,7 @@
 | sharedelementtransition | [WIP] Fragment 間の遷移時に Shared Element Transition を利用するサンプル<br/>RecyclerView のセルからの遷移は上手くいかない | 1.0.0-alpha06 |
 | toolbar | Toolbar 単体で利用する Activity のサンプル(#33)<br/>argument を Toolbar のタイトルに利用している(#58) | 1.0.0-alpha03 |
 | dialog | Dialog への遷移、Dialog から遷移するサンプル(#24) | 2.1.0-beta02 |
+| navgraphviewmodels | Navigation Graph で共有する ViewModels (#23)<br/>2.2.0 から SavedStateHandle にも対応(#27) | 2.1.0-rc01 |
 
 ### app
 
@@ -41,6 +39,26 @@
 ## 更新履歴
 
 https://developer.android.com/jetpack/androidx/releases/navigation
+
+### [2.2.0-beta01](https://developer.android.com/jetpack/androidx/releases/navigation#2.2.0-beta01)
+
+* `NavDestination` のサブクラスで `toString` をオーバーライドできるようになった
+* マッチしない deep link を無視するようになった
+
+### [2.2.0-alpha03](https://developer.android.com/jetpack/androidx/releases/navigation#2.2.0-alpha03)
+
+* `setGraph` の後に `setViewModelStore` を呼び出したら `IllegalStateException` になるように変更された
+
+### [2.2.0-alpha02](https://developer.android.com/jetpack/androidx/releases/navigation#2.2.0-alpha02)
+
+* deep link のパラメータのデフォルト値や nullable にサポート
+* `NavController.getBackStackEntry()` でバックスタックの ID や NavigationGraph を渡せるようになった
+
+### [2.2.0-alpha01](https://developer.android.com/jetpack/androidx/releases/navigation#2.2.0-alpha01)
+
+* `SavedStateViewModelFactory` がデフォルトで利用されるようになった
+  * Navigation Graph スコープの ViewModel が SavedState をサポートしてくれる
+* `NavController#getViewModelStore()` が deprecated になった
 
 ### 2.1.0-beta02
 

--- a/NavigationSample/build.gradle
+++ b/NavigationSample/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.constraint_layout_version = '1.1.3'
     ext.ktx_version = '1.0.0'
     ext.lifecycle_version = '2.1.0'
-    ext.nav_version = '2.1.0'
+    ext.nav_version = '2.2.0-beta01'
     repositories {
         google()
         jcenter()

--- a/NavigationSample/build.gradle
+++ b/NavigationSample/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/NavigationSample/navgraphviewmodels/src/main/java/com/github/mag0716/navigationsample/navgraphviewmodels/FirstFragment.kt
+++ b/NavigationSample/navgraphviewmodels/src/main/java/com/github/mag0716/navigationsample/navgraphviewmodels/FirstFragment.kt
@@ -25,8 +25,8 @@ class FirstFragment : androidx.fragment.app.Fragment() {
         super.onViewCreated(view, savedInstanceState)
         button.setOnClickListener(Navigation.createNavigateOnClickListener(R.id.action_move_to_second))
         countButton.setOnClickListener {
-            activityScopeViewModel.count++
-            navGraphScopeViewModel.count++
+            activityScopeViewModel.increment()
+            navGraphScopeViewModel.increment()
             updateText()
         }
         updateText()

--- a/NavigationSample/navgraphviewmodels/src/main/java/com/github/mag0716/navigationsample/navgraphviewmodels/SampleViewModel.kt
+++ b/NavigationSample/navgraphviewmodels/src/main/java/com/github/mag0716/navigationsample/navgraphviewmodels/SampleViewModel.kt
@@ -1,8 +1,21 @@
 package com.github.mag0716.navigationsample.navgraphviewmodels
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 
-class SampleViewModel : ViewModel() {
+class SampleViewModel(
+        private val savedStateHandle: SavedStateHandle
+) : ViewModel() {
 
-    var count: Int = 0
+    companion object {
+        private const val KEY_COUNT = "count"
+    }
+
+    var count: Int = savedStateHandle.get<Int>(KEY_COUNT) ?: 0
+        private set
+
+    fun increment() {
+        count++
+        savedStateHandle.set(KEY_COUNT, count)
+    }
 }


### PR DESCRIPTION
## 概要

https://developer.android.com/jetpack/androidx/releases/navigation

## TODO

- [x] SavedStateHandle 対応
- [ ] 動作確認

## 変更された動作

### navgraphviewmodels

#### 2.1.0

* Activity 破棄後の復帰では activityViewModel, navViewModel とも 0 になる

#### 2.2.0

* 単純にバージョンを上げただけでは変わらない
* ViewModel のコンストラクタに `SavedStateHandle` を渡して、get/set するだけで対応できる