### PR TITLE
Bokeh の Extensions を有効にする

### DIFF
--- a/CameraXSample/app/build.gradle
+++ b/CameraXSample/app/build.gradle
@@ -38,5 +38,5 @@ dependencies {
     implementation "androidx.camera:camera-camera2:${camerax_version}"
     implementation "androidx.camera:camera-lifecycle:${camerax_version}"
     implementation "androidx.camera:camera-view:${camerax_view_version}"
-    //implementation "androidx.camera:camera-extensions:${camerax_extensions_version}"
+    implementation "androidx.camera:camera-extensions:${camerax_extensions_version}"
 }

--- a/CameraXSample/build.gradle
+++ b/CameraXSample/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.3.70'
     ext.camerax_version = "1.0.0-beta02"
-    ext.camerax_extensions_version = "1.0.0-alpha01"
+    ext.camerax_extensions_version = "1.0.0-alpha09"
     ext.camerax_view_version = "1.0.0-alpha09"
     repositories {
         google()


### PR DESCRIPTION
https://developer.android.com/training/camerax/vendor-extensions を参考に
`BokehPreviewExtender` を有効にする処理を実装したが、
Pixel4 では`isExtensionAvailable` が `false` だった有効にならず動作確認できなかった。

## 関連 Issue

#9 